### PR TITLE
Allow text 2.1

### DIFF
--- a/typst-symbols.cabal
+++ b/typst-symbols.cabal
@@ -27,6 +27,6 @@ library
                       Typst.Shorthands
                       Typst.Emoji
     build-depends:    base >= 4.12 && < 5,
-                      text >= 1.0 && < 2.1
+                      text >= 1.0 && < 2.2
     hs-source-dirs:   src
     default-language: Haskell2010


### PR DESCRIPTION
Hello, this is a tiny PR to increase the upper bound on text to 2.1.
Would it be possible to also bump the upper bound on Hackage? This can be done with a metadata revision (rather than another release).